### PR TITLE
65 - Bug fix: BERTModel same outputs at validation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,16 @@
             "type": "python",
             "request": "launch",
             "program": "${workspaceRoot}/src/main.py",
-            "args": [],
+            "args": [
+        "--train_all", "1",
+        "--ds1.train.batch_size", "10",
+        "--ds2.train.batch_size", "10",
+        "--ds1.train.slicing", "[:100]",
+        "--ds2.train.slicing", "[:100]",
+        "--has_learning_rate_decay", "1",
+
+
+            ],
             "cwd": "${workspaceFolder}"
         },
         {


### PR DESCRIPTION
Changes learning rate for the default configuration that uses BERTModel such that it is low and the model doesn't diverge far. 

Bug: the model outputs the same logits no matter what input.

Refs:
- https://github.com/huggingface/transformers/issues/735
- https://stackoverflow.com/questions/61855486/bert-encoding-layer-produces-same-output-for-all-inputs-during-evaluation-pytor